### PR TITLE
Fixed error, if the number of items is less than remain.

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@
                 }
 
                 delta.end = end
-                delta.start = start
+                if (start >= this.remain) delta.start = start
 
                 this.$forceUpdate()
                 Vue2.nextTick(this.setScrollTop.bind(this, scrollTop))


### PR DESCRIPTION
Fixed error, if the number of items is less than remain,when start props is setted, it would appear unexpected blank.