### PR TITLE
Fix typo in class name

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ The `<Item>` component is included inside but defined outside the `<virtualList>
 ```
 
 ```javascript
-// Global name as `VirutalScrollList`
-Vue.component('virtual-list', VirutalScrollList)
+// Global name as `VirtualScrollList`
+Vue.component('virtual-list', VirtualScrollList)
 
 new Vue({
     el: '#app',

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@
     } else {
         root[ns] = factory(root['Vue'])
     }
-})(this, 'VirutalScrollList', function (Vue2) {
+})(this, 'VirtualScrollList', function (Vue2) {
     if (typeof Vue2 === 'object' && typeof Vue2.default === 'function') {
         Vue2 = Vue2.default
     }


### PR DESCRIPTION
`VirutalScrollList` has a typo, should be `VirtualScrollList`