### PR TITLE
New Prop to customize offset to trigger tobottom

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,6 +42,7 @@
             wtag: { type: String, default: 'div' },
             wclass: { type: String, default: '' },
             start: { type: Number, default: 0 },
+          increaseToBottomLimit: { type: Number, default: 0 },
             variable: Function,
             bench: Number,
             debounce: Number,
@@ -96,7 +97,7 @@
                     this.updateZone(offset)
                 }
 
-                if (offset >= delta.offsetAll) {
+                if (offset >= delta.offsetAll - this.increaseToBottomLimit) {
                     this.triggerEvent('tobottom')
                 }
 


### PR DESCRIPTION
You can pass a new prop that can change the boundary limit to trigger `tobottom` event.

It's important to people that want to fill their `item list` before to reach the bottom limit.

It should be a number, that represents the offset in pixels.