### PR TITLE
Mark the onscroll as passive

### DIFF
--- a/index.js
+++ b/index.js
@@ -369,7 +369,7 @@
                     'height': this.size * this.remain + 'px'
                 },
                 'on': {
-                    'scroll': dbc ? _debounce(this.onScroll.bind(this), dbc) : this.onScroll
+                    '&scroll': dbc ? _debounce(this.onScroll.bind(this), dbc) : this.onScroll
                 }
             }, [
                 h(this.wtag, {


### PR DESCRIPTION
I'm not sure if you were avoiding this on purpose but there's a flag in vue to mark the scroll as passive. 

https://vuejs.org/v2/guide/render-function.html#Event-amp-Key-Modifiers

This allows chrome to know that you aren't going to disable the scroll. It does mean you have to have a larger `bench` but I found that it made heavy items scroll waaaaay faster.