### PR TITLE
Add custom root element class name support

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,6 +40,7 @@
             remain: { type: Number, required: true },
             rtag: { type: String, default: 'div' },
             wtag: { type: String, default: 'div' },
+            rclass: { type: String, default: '' },
             wclass: { type: String, default: '' },
             start: { type: Number, default: 0 },
             offset: { type: Number, default: 0 },
@@ -368,6 +369,7 @@
                     'overflow-y': 'auto',
                     'height': this.size * this.remain + 'px'
                 },
+                'class': this.rclass,
                 'on': {
                     '&scroll': dbc ? _debounce(this.onScroll.bind(this), dbc) : this.onScroll
                 }


### PR DESCRIPTION
`rclass` prop was removed in [#e5061b3](https://github.com/tangbc/vue-virtual-scroll-list/commit/e5061b3bd3257693e330968fc940fd24a9fcea88), but it's not easy in the case of customizing style of root element. 