### PR TITLE
[Fix] Always render all slots

### DIFF
--- a/index.js
+++ b/index.js
@@ -318,7 +318,7 @@
                 delta.offsetAll = allHeight - this.size * this.remain
 
                 var targets = []
-                for (var i = delta.start; i <= delta.end; i++) {
+                for (var i = delta.start; i <= Math.ceil(delta.end); i++) {
                     targets.push(slots[i])
                 }
                 return targets


### PR DESCRIPTION
List height is determined by item height and visible items number (`remain` prop) and this works flawless as long as this number is {Integer}. But... when `remain` prop is set dynamically to {Float} (for ex.: list fills all available vertical space in UI), last item in scrollable list won't be rendered (for ex.: `delta.end` can equal `58.6` for 59 items, so only 58 slots are rendered).

This solution fixes the problem.