### PR TITLE
support component for $refs.vsl

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,7 +90,8 @@
         methods: {
             onScroll: function (e) {
                 var delta = this.delta
-                var offset = (this.$refs.vsl && this.$refs.vsl.scrollTop) || 0
+                var vsl = this.$refs.vsl;
+                var offset = (vsl && (vsl instanceof Vue2 ? vsl.$el : vsl).scrollTop) || 0
 
                 if (delta.total > delta.keeps) {
                     this.updateZone(offset)
@@ -284,7 +285,7 @@
             setScrollTop: function (scrollTop) {
                 var vsl = this.$refs.vsl
                 if (vsl) {
-                    vsl.scrollTop = scrollTop
+                    (vsl instanceof Vue2 ? vsl.$el : vsl).scrollTop = scrollTop
                 }
             },
 

--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@
         methods: {
             onScroll: function (e) {
                 var delta = this.delta
-                var vsl = this.$refs.vsl;
+                var vsl = this.$refs.vsl
                 var offset = (vsl && (vsl instanceof Vue2 ? vsl.$el : vsl).scrollTop) || 0
 
                 if (delta.total > delta.keeps) {


### PR DESCRIPTION
I'm trying to use [vue2-perfect-scrollbar](https://www.npmjs.com/package/vue2-perfect-scrollbar) in `vue-virtual-scroll-list`. The only problem that happen is the way to get the offset value.

`vue2-perfect-scrollbar` makes the structure become like this:

<img width="228" alt="screen shot 2018-12-18 at 09 59 14" src="https://user-images.githubusercontent.com/6095638/50129467-9ab92980-02ab-11e9-8fc7-e838faf66ef3.png">

So, it needs to check whether the `$refs.vsl` is a Vue component or not to get the correct scrollTop value.