### PR TITLE
Add '-webkit-overflow-scrolling: touch' to scroller

### DIFF
--- a/index.js
+++ b/index.js
@@ -384,7 +384,8 @@
                 'style': {
                     'display': 'block',
                     'overflow-y': 'auto',
-                    'height': this.size * this.remain + 'px'
+                    'height': this.size * this.remain + 'px',
+                    '-webkit-overflow-scrolling': 'touch'
                 },
                 'on': {
                     '&scroll': dbc ? _debounce(this.onScroll.bind(this), dbc) : this.onScroll


### PR DESCRIPTION
Make scroll behavior smooth in mobile browsers.