### PR TITLE
Remove unnecessary padding bottom when decimal number is used

### DIFF
--- a/index.js
+++ b/index.js
@@ -347,6 +347,10 @@
                     paddingBottom = this.size * (hasPadding ? delta.total - delta.keeps : 0) - paddingTop
                 }
 
+                if (paddingBottom < this.size) {
+                    paddingBottom = 0
+                }
+
                 delta.paddingTop = paddingTop
                 delta.paddingBottom = paddingBottom
                 delta.offsetAll = allHeight - this.size * this.remain


### PR DESCRIPTION
When we are defining `remain` value via `containerHeight / size` (because the `containerHeight` is a fixed value), it can lead us to have decimal value on `remain` variable.

Because of it, we will have this extra padding shown by gif below:


<p align="center">
  <img src="https://user-images.githubusercontent.com/6095638/53685951-fac05780-3d53-11e9-9569-36bf1ec8f7da.gif" width="50%"  align="center" />
</p>

In the case above, I use `6.6` as the value of `remain`.