### PR TITLE
Adding a group role to the list item container to allow better aria-support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,460 +1,466 @@
 (function (root, factory) {
-    var namespace = 'VirtualScrollList'
-    /* istanbul ignore next */
-    if (typeof exports === 'object' && typeof module === 'object') {
-        module.exports = factory(namespace, require('vue'))
-    } else if (typeof define === 'function' && define.amd) {
-        define(['vue'], factory.bind(root, namespace))
-    } else if (typeof exports === 'object') {
-        exports[namespace] = factory(namespace, require('vue'))
-    } else {
-        root[namespace] = factory(namespace, root['Vue'])
-    }
+	var namespace = 'VirtualScrollList';
+	/* istanbul ignore next */
+	if (typeof exports === 'object' && typeof module === 'object') {
+		module.exports = factory(namespace, require('vue'));
+	} else if (typeof define === 'function' && define.amd) {
+		define([ 'vue' ], factory.bind(root, namespace));
+	} else if (typeof exports === 'object') {
+		exports[namespace] = factory(namespace, require('vue'));
+	} else {
+		root[namespace] = factory(namespace, root['Vue']);
+	}
 })(this, function (namespace, Vue2) {
-    /* istanbul ignore next */
-    if (typeof Vue2 === 'object' && typeof Vue2.default === 'function') {
-        Vue2 = Vue2.default
-    }
+	/* istanbul ignore next */
+	if (typeof Vue2 === 'object' && typeof Vue2.default === 'function') {
+		Vue2 = Vue2.default;
+	}
 
-    /* istanbul ignore next */
-    var _debounce = function (func, wait, immediate) {
-        var timeout
-        return function () {
-            var context = this
-            var args = arguments
-            var later = function () {
-                timeout = null
-                if (!immediate) {
-                    func.apply(context, args)
-                }
-            }
-            var callNow = immediate && !timeout
-            clearTimeout(timeout)
-            timeout = setTimeout(later, wait)
-            if (callNow) {
-                func.apply(context, args)
-            }
-        }
-    }
+	/* istanbul ignore next */
+	var _debounce = function (func, wait, immediate) {
+		var timeout;
+		return function () {
+			var context = this;
+			var args = arguments;
+			var later = function () {
+				timeout = null;
+				if (!immediate) {
+					func.apply(context, args);
+				}
+			};
+			var callNow = immediate && !timeout;
+			clearTimeout(timeout);
+			timeout = setTimeout(later, wait);
+			if (callNow) {
+				func.apply(context, args);
+			}
+		};
+	};
 
-    return Vue2.component(namespace, {
-        props: {
-            size: { type: Number, required: true },
-            remain: { type: Number, required: true },
-            rtag: { type: String, default: 'div' },
-            wtag: { type: String, default: 'div' },
-            wclass: { type: String, default: '' },
-            start: { type: Number, default: 0 },
-            offset: { type: Number, default: 0 },
-            variable: [Function, Boolean],
-            bench: Number,
-            debounce: Number,
-            totop: Function,
-            tobottom: Function,
-            onscroll: Function,
-            item: { type: Object },
-            itemcount: { type: Number },
-            itemprops: { type: Function }
-        },
+	return Vue2.component(namespace, {
+		props: {
+			size: { type: Number, required: true },
+			remain: { type: Number, required: true },
+			rtag: { type: String, default: 'div' },
+			wtag: { type: String, default: 'div' },
+			wclass: { type: String, default: '' },
+			start: { type: Number, default: 0 },
+			offset: { type: Number, default: 0 },
+			variable: [ Function, Boolean ],
+			bench: Number,
+			debounce: Number,
+			totop: Function,
+			tobottom: Function,
+			onscroll: Function,
+			item: { type: Object },
+			itemcount: { type: Number },
+			itemprops: { type: Function }
+		},
 
-        created: function () {
-            var start = this.start >= this.remain ? this.start : 0
-            var keeps = this.remain + (this.bench || this.remain)
+		created: function () {
+			var start = this.start >= this.remain ? this.start : 0;
+			var keeps = this.remain + (this.bench || this.remain);
 
-            this.delta = {
-                direction: '', // current scroll direction, D: down, U: up.
-                scrollTop: 0, // current scroll top, use to direction.
-                start: start, // start index.
-                end: start + keeps - 1, // end index.
-                keeps: keeps, // nums keeping in real dom.
-                total: 0, // all items count, update in filter.
-                offsetAll: 0, // cache all the scrollable offset.
-                paddingTop: 0, // container wrapper real padding-top.
-                paddingBottom: 0, // container wrapper real padding-bottom.
-                varCache: {}, // object to cache variable index height and scroll offset.
-                varAverSize: 0, // average/estimate item height before variable be calculated.
-                varLastCalcIndex: 0 // last calculated variable height/offset index, always increase.
-            }
-        },
+			this.delta = {
+				direction: '', // current scroll direction, D: down, U: up.
+				scrollTop: 0, // current scroll top, use to direction.
+				start: start, // start index.
+				end: start + keeps - 1, // end index.
+				keeps: keeps, // nums keeping in real dom.
+				total: 0, // all items count, update in filter.
+				offsetAll: 0, // cache all the scrollable offset.
+				paddingTop: 0, // container wrapper real padding-top.
+				paddingBottom: 0, // container wrapper real padding-bottom.
+				varCache: {}, // object to cache variable index height and scroll offset.
+				varAverSize: 0, // average/estimate item height before variable be calculated.
+				varLastCalcIndex: 0 // last calculated variable height/offset index, always increase.
+			};
+		},
 
-        // use alter to identify which prop change.
-        watch: {
-            size: function () {
-                this.alter = 'size'
-            },
-            remain: function () {
-                this.alter = 'remain'
-            },
-            bench: function () {
-                this.alter = 'bench'
-                this.itemModeForceRender()
-            },
-            start: function () {
-                this.alter = 'start'
-                this.itemModeForceRender()
-            },
-            offset: function () {
-                this.alter = 'offset'
-                this.itemModeForceRender()
-            },
-            itemcount: function () {
-                this.alter = 'itemcount'
-                this.itemModeForceRender()
-            }
-        },
+		// use alter to identify which prop change.
+		watch: {
+			size: function () {
+				this.alter = 'size';
+			},
+			remain: function () {
+				this.alter = 'remain';
+			},
+			bench: function () {
+				this.alter = 'bench';
+				this.itemModeForceRender();
+			},
+			start: function () {
+				this.alter = 'start';
+				this.itemModeForceRender();
+			},
+			offset: function () {
+				this.alter = 'offset';
+				this.itemModeForceRender();
+			},
+			itemcount: function () {
+				this.alter = 'itemcount';
+				this.itemModeForceRender();
+			}
+		},
 
-        methods: {
-            onScroll: function (e) {
-                var delta = this.delta
-                var vsl = this.$refs.vsl
-                var offset = (vsl.$el || vsl).scrollTop || 0
+		methods: {
+			onScroll: function (e) {
+				var delta = this.delta;
+				var vsl = this.$refs.vsl;
+				var offset = (vsl.$el || vsl).scrollTop || 0;
 
-                delta.direction = offset > delta.scrollTop ? 'D' : 'U'
-                delta.scrollTop = offset
+				delta.direction = offset > delta.scrollTop ? 'D' : 'U';
+				delta.scrollTop = offset;
 
-                if (delta.total > delta.keeps) {
-                    this.updateZone(offset)
-                } else {
-                    delta.end = delta.total - 1
-                }
+				if (delta.total > delta.keeps) {
+					this.updateZone(offset);
+				} else {
+					delta.end = delta.total - 1;
+				}
 
-                var offsetAll = delta.offsetAll
-                if (this.onscroll) {
-                    this.onscroll(e, {
-                        offset: offset,
-                        offsetAll: offsetAll,
-                        start: delta.start,
-                        end: delta.end
-                    })
-                }
+				var offsetAll = delta.offsetAll;
+				if (this.onscroll) {
+					this.onscroll(e, {
+						offset: offset,
+						offsetAll: offsetAll,
+						start: delta.start,
+						end: delta.end
+					});
+				}
 
-                if (!offset && delta.total) {
-                    this.fireEvent('totop')
-                }
+				if (!offset && delta.total) {
+					this.fireEvent('totop');
+				}
 
-                if (offset >= offsetAll) {
-                    this.fireEvent('tobottom')
-                }
-            },
+				if (offset >= offsetAll) {
+					this.fireEvent('tobottom');
+				}
+			},
 
-            // update render zone by scroll offset.
-            updateZone: function (offset) {
-                var delta = this.delta
-                var overs = this.variable
-                    ? this.getVarOvers(offset)
-                    : Math.floor(offset / this.size)
+			// update render zone by scroll offset.
+			updateZone: function (offset) {
+				var delta = this.delta;
+				var overs = this.variable ? this.getVarOvers(offset) : Math.floor(offset / this.size);
 
-                // if scroll up, we'd better decrease it's numbers.
-                if (delta.direction === 'U') {
-                    overs = overs - this.remain + 1
-                }
+				// if scroll up, we'd better decrease it's numbers.
+				if (delta.direction === 'U') {
+					overs = overs - this.remain + 1;
+				}
 
-                var zone = this.getZone(overs)
-                var bench = this.bench || this.remain
+				var zone = this.getZone(overs);
+				var bench = this.bench || this.remain;
 
-                // for better performance, if scroll pass items within now bench, do not update.
-                // and if overs is going to reach last item, we should render next zone immediately.
-                var shouldRenderNextZone = Math.abs(overs - delta.start - bench) === 1
-                if (
-                    !shouldRenderNextZone &&
-                    (overs - delta.start <= bench) &&
-                    !zone.isLast && (overs > delta.start)
-                ) {
-                    return
-                }
+				// for better performance, if scroll pass items within now bench, do not update.
+				// and if overs is going to reach last item, we should render next zone immediately.
+				var shouldRenderNextZone = Math.abs(overs - delta.start - bench) === 1;
+				if (!shouldRenderNextZone && overs - delta.start <= bench && !zone.isLast && overs > delta.start) {
+					return;
+				}
 
-                // we'd better make sure forceRender calls as less as possible.
-                if (shouldRenderNextZone || zone.start !== delta.start || zone.end !== delta.end) {
-                    delta.end = zone.end
-                    delta.start = zone.start
-                    this.forceRender()
-                }
-            },
+				// we'd better make sure forceRender calls as less as possible.
+				if (shouldRenderNextZone || zone.start !== delta.start || zone.end !== delta.end) {
+					delta.end = zone.end;
+					delta.start = zone.start;
+					this.forceRender();
+				}
+			},
 
-            // return the right zone info base on `start/index`.
-            getZone: function (index) {
-                var start, end
-                var delta = this.delta
+			// return the right zone info base on `start/index`.
+			getZone: function (index) {
+				var start, end;
+				var delta = this.delta;
 
-                index = parseInt(index, 10)
-                index = Math.max(0, index)
+				index = parseInt(index, 10);
+				index = Math.max(0, index);
 
-                var lastStart = delta.total - delta.keeps
-                var isLast = (index <= delta.total && index >= lastStart) || (index > delta.total)
-                if (isLast) {
-                    end = delta.total - 1
-                    start = Math.max(0, lastStart)
-                } else {
-                    start = index
-                    end = start + delta.keeps - 1
-                }
+				var lastStart = delta.total - delta.keeps;
+				var isLast = (index <= delta.total && index >= lastStart) || index > delta.total;
+				if (isLast) {
+					end = delta.total - 1;
+					start = Math.max(0, lastStart);
+				} else {
+					start = index;
+					end = start + delta.keeps - 1;
+				}
 
-                return {
-                    end: end,
-                    start: start,
-                    isLast: isLast
-                }
-            },
+				return {
+					end: end,
+					start: start,
+					isLast: isLast
+				};
+			},
 
-            // public method, force render ui list if we needed.
-            // call this before the next repaint to get better performance.
-            forceRender: function () {
-                var that = this
-                window.requestAnimationFrame(function () {
-                    that.$forceUpdate()
-                })
-            },
+			// public method, force render ui list if we needed.
+			// call this before the next repaint to get better performance.
+			forceRender: function () {
+				var that = this;
+				window.requestAnimationFrame(function () {
+					that.$forceUpdate();
+				});
+			},
 
-            // force render ui if using item mode.
-            itemModeForceRender: function () {
-                if (this.item) {
-                    this.forceRender()
-                }
-            },
+			// force render ui if using item mode.
+			itemModeForceRender: function () {
+				if (this.item) {
+					this.forceRender();
+				}
+			},
 
-            // return the scroll passed items count in variable.
-            getVarOvers: function (offset) {
-                var low = 0
-                var middle = 0
-                var middleOffset = 0
-                var delta = this.delta
-                var high = delta.total
+			// return the scroll passed items count in variable.
+			getVarOvers: function (offset) {
+				var low = 0;
+				var middle = 0;
+				var middleOffset = 0;
+				var delta = this.delta;
+				var high = delta.total;
 
-                while (low <= high) {
-                    middle = low + Math.floor((high - low) / 2)
-                    middleOffset = this.getVarOffset(middle)
+				while (low <= high) {
+					middle = low + Math.floor((high - low) / 2);
+					middleOffset = this.getVarOffset(middle);
 
-                    // calculate the average variable height at first binary search.
-                    if (!delta.varAverSize) {
-                        delta.varAverSize = Math.floor(middleOffset / middle)
-                    }
+					// calculate the average variable height at first binary search.
+					if (!delta.varAverSize) {
+						delta.varAverSize = Math.floor(middleOffset / middle);
+					}
 
-                    if (middleOffset === offset) {
-                        return middle
-                    } else if (middleOffset < offset) {
-                        low = middle + 1
-                    } else if (middleOffset > offset) {
-                        high = middle - 1
-                    }
-                }
+					if (middleOffset === offset) {
+						return middle;
+					} else if (middleOffset < offset) {
+						low = middle + 1;
+					} else if (middleOffset > offset) {
+						high = middle - 1;
+					}
+				}
 
-                return low > 0 ? --low : 0
-            },
+				return low > 0 ? --low : 0;
+			},
 
-            // return a variable scroll offset from given index.
-            getVarOffset: function (index, nocache) {
-                var delta = this.delta
-                var cache = delta.varCache[index]
+			// return a variable scroll offset from given index.
+			getVarOffset: function (index, nocache) {
+				var delta = this.delta;
+				var cache = delta.varCache[index];
 
-                if (!nocache && cache) {
-                    return cache.offset
-                }
+				if (!nocache && cache) {
+					return cache.offset;
+				}
 
-                var offset = 0
-                for (var i = 0; i < index; i++) {
-                    var size = this.getVarSize(i, nocache)
-                    delta.varCache[i] = {
-                        size: size,
-                        offset: offset
-                    }
-                    offset += size
-                }
+				var offset = 0;
+				for (var i = 0; i < index; i++) {
+					var size = this.getVarSize(i, nocache);
+					delta.varCache[i] = {
+						size: size,
+						offset: offset
+					};
+					offset += size;
+				}
 
-                delta.varLastCalcIndex = Math.max(delta.varLastCalcIndex, index - 1)
-                delta.varLastCalcIndex = Math.min(delta.varLastCalcIndex, delta.total - 1)
+				delta.varLastCalcIndex = Math.max(delta.varLastCalcIndex, index - 1);
+				delta.varLastCalcIndex = Math.min(delta.varLastCalcIndex, delta.total - 1);
 
-                return offset
-            },
+				return offset;
+			},
 
-            // return a variable size (height) from given index.
-            getVarSize: function (index, nocache) {
-                var cache = this.delta.varCache[index]
-                if (!nocache && cache) {
-                    return cache.size
-                }
+			// return a variable size (height) from given index.
+			getVarSize: function (index, nocache) {
+				var cache = this.delta.varCache[index];
+				if (!nocache && cache) {
+					return cache.size;
+				}
 
-                if (typeof this.variable === 'function') {
-                    return this.variable(index) || 0
-                } else {
-                    // when using item, it can only get current components height,
-                    // need to be enhanced, or consider using variable-function instead
-                    var slot = this.item
-                        ? (this.$children[index] ? this.$children[index].$vnode : null)
-                        : this.$slots.default[index]
+				if (typeof this.variable === 'function') {
+					return this.variable(index) || 0;
+				} else {
+					// when using item, it can only get current components height,
+					// need to be enhanced, or consider using variable-function instead
+					var slot = this.item
+						? this.$children[index] ? this.$children[index].$vnode : null
+						: this.$slots.default[index];
 
-                    var style = slot && slot.data && slot.data.style
-                    if (style && style.height) {
-                        var shm = style.height.match(/^(.*)px$/)
-                        return (shm && +shm[1]) || 0
-                    }
-                }
-                return 0
-            },
+					var style = slot && slot.data && slot.data.style;
+					if (style && style.height) {
+						var shm = style.height.match(/^(.*)px$/);
+						return (shm && +shm[1]) || 0;
+					}
+				}
+				return 0;
+			},
 
-            // return the variable paddingTop base current zone.
-            // @todo: if set a large `start` before variable was calculated,
-            // here will also case too much offset calculate when list is very large,
-            // consider use estimate paddingTop in this case just like `getVarPaddingBottom`.
-            getVarPaddingTop: function () {
-                return this.getVarOffset(this.delta.start)
-            },
+			// return the variable paddingTop base current zone.
+			// @todo: if set a large `start` before variable was calculated,
+			// here will also case too much offset calculate when list is very large,
+			// consider use estimate paddingTop in this case just like `getVarPaddingBottom`.
+			getVarPaddingTop: function () {
+				return this.getVarOffset(this.delta.start);
+			},
 
-            // return the variable paddingBottom base current zone.
-            getVarPaddingBottom: function () {
-                var delta = this.delta
-                var last = delta.total - 1
-                if (delta.total - delta.end <= delta.keeps || delta.varLastCalcIndex === last) {
-                    return this.getVarOffset(last) - this.getVarOffset(delta.end)
-                } else {
-                    // if unreached last zone or uncalculate real behind offset
-                    // return the estimate paddingBottom avoid too much calculate.
-                    return (delta.total - delta.end) * (delta.varAverSize || this.size)
-                }
-            },
+			// return the variable paddingBottom base current zone.
+			getVarPaddingBottom: function () {
+				var delta = this.delta;
+				var last = delta.total - 1;
+				if (delta.total - delta.end <= delta.keeps || delta.varLastCalcIndex === last) {
+					return this.getVarOffset(last) - this.getVarOffset(delta.end);
+				} else {
+					// if unreached last zone or uncalculate real behind offset
+					// return the estimate paddingBottom avoid too much calculate.
+					return (delta.total - delta.end) * (delta.varAverSize || this.size);
+				}
+			},
 
-            // retun the variable all heights use to judge reach bottom.
-            getVarAllHeight: function () {
-                var delta = this.delta
-                if (delta.total - delta.end <= delta.keeps || delta.varLastCalcIndex === delta.total - 1) {
-                    return this.getVarOffset(delta.total)
-                } else {
-                    return this.getVarOffset(delta.start) + (delta.total - delta.end) * (delta.varAverSize || this.size)
-                }
-            },
+			// retun the variable all heights use to judge reach bottom.
+			getVarAllHeight: function () {
+				var delta = this.delta;
+				if (delta.total - delta.end <= delta.keeps || delta.varLastCalcIndex === delta.total - 1) {
+					return this.getVarOffset(delta.total);
+				} else {
+					return (
+						this.getVarOffset(delta.start) + (delta.total - delta.end) * (delta.varAverSize || this.size)
+					);
+				}
+			},
 
-            // public method, allow the parent update variable by index.
-            updateVariable: function (index) {
-                // clear/update all the offfsets and heights ahead of index.
-                this.getVarOffset(index, true)
-            },
+			// public method, allow the parent update variable by index.
+			updateVariable: function (index) {
+				// clear/update all the offfsets and heights ahead of index.
+				this.getVarOffset(index, true);
+			},
 
-            // trigger a props event on parent.
-            fireEvent: function (event) {
-                if (this[event]) {
-                    this[event]()
-                }
-            },
+			// trigger a props event on parent.
+			fireEvent: function (event) {
+				if (this[event]) {
+					this[event]();
+				}
+			},
 
-            // set manual scroll top.
-            setScrollTop: function (scrollTop) {
-                var vsl = this.$refs.vsl
-                if (vsl) {
-                    (vsl.$el || vsl).scrollTop = scrollTop
-                }
-            },
+			// set manual scroll top.
+			setScrollTop: function (scrollTop) {
+				var vsl = this.$refs.vsl;
+				if (vsl) {
+					(vsl.$el || vsl).scrollTop = scrollTop;
+				}
+			},
 
-            // filter the shown items base on `start` and `end`.
-            filter: function () {
-                var delta = this.delta
-                var slots = this.$slots.default
+			// filter the shown items base on `start` and `end`.
+			filter: function () {
+				var delta = this.delta;
+				var slots = this.$slots.default;
 
-                // item mode shoud judge from items prop.
-                if (this.item) {
-                    delta.total = this.itemcount
-                } else {
-                    if (!slots) {
-                        slots = []
-                        delta.start = 0
-                    }
-                    delta.total = slots.length
-                }
+				// item mode shoud judge from items prop.
+				if (this.item) {
+					delta.total = this.itemcount;
+				} else {
+					if (!slots) {
+						slots = [];
+						delta.start = 0;
+					}
+					delta.total = slots.length;
+				}
 
-                var paddingTop, paddingBottom, allHeight
-                var hasPadding = delta.total > delta.keeps
+				var paddingTop, paddingBottom, allHeight;
+				var hasPadding = delta.total > delta.keeps;
 
-                if (this.variable) {
-                    allHeight = this.getVarAllHeight()
-                    paddingTop = hasPadding ? this.getVarPaddingTop() : 0
-                    paddingBottom = hasPadding ? this.getVarPaddingBottom() : 0
-                } else {
-                    allHeight = this.size * delta.total
-                    paddingTop = this.size * (hasPadding ? delta.start : 0)
-                    paddingBottom = this.size * (hasPadding ? delta.total - delta.keeps : 0) - paddingTop
-                }
+				if (this.variable) {
+					allHeight = this.getVarAllHeight();
+					paddingTop = hasPadding ? this.getVarPaddingTop() : 0;
+					paddingBottom = hasPadding ? this.getVarPaddingBottom() : 0;
+				} else {
+					allHeight = this.size * delta.total;
+					paddingTop = this.size * (hasPadding ? delta.start : 0);
+					paddingBottom = this.size * (hasPadding ? delta.total - delta.keeps : 0) - paddingTop;
+				}
 
-                if (paddingBottom < this.size) {
-                    paddingBottom = 0
-                }
+				if (paddingBottom < this.size) {
+					paddingBottom = 0;
+				}
 
-                delta.paddingTop = paddingTop
-                delta.paddingBottom = paddingBottom
-                delta.offsetAll = allHeight - this.size * this.remain
+				delta.paddingTop = paddingTop;
+				delta.paddingBottom = paddingBottom;
+				delta.offsetAll = allHeight - this.size * this.remain;
 
-                var targets = []
-                for (var i = delta.start; i <= Math.ceil(delta.end); i++) {
-                    // create vnode, using custom attrs binder.
-                    var slot = this.item && this.itemprops
-                        ? this.$createElement(this.item, this.itemprops(i))
-                        : slots[i]
-                    targets.push(slot)
-                }
+				var targets = [];
+				for (var i = delta.start; i <= Math.ceil(delta.end); i++) {
+					// create vnode, using custom attrs binder.
+					var slot =
+						this.item && this.itemprops ? this.$createElement(this.item, this.itemprops(i)) : slots[i];
+					targets.push(slot);
+				}
 
-                return targets
-            }
-        },
+				return targets;
+			}
+		},
 
-        mounted: function () {
-            if (this.start) {
-                var start = this.getZone(this.start).start
-                this.setScrollTop(this.variable ? this.getVarOffset(start) : start * this.size)
-            } else if (this.offset) {
-                this.setScrollTop(this.offset)
-            }
-        },
+		mounted: function () {
+			if (this.start) {
+				var start = this.getZone(this.start).start;
+				this.setScrollTop(this.variable ? this.getVarOffset(start) : start * this.size);
+			} else if (this.offset) {
+				this.setScrollTop(this.offset);
+			}
+		},
 
-        // check if delta should update when prorps change.
-        beforeUpdate: function () {
-            var delta = this.delta
-            delta.keeps = this.remain + (this.bench || this.remain)
+		// check if delta should update when prorps change.
+		beforeUpdate: function () {
+			var delta = this.delta;
+			delta.keeps = this.remain + (this.bench || this.remain);
 
-            var calcstart = this.alter === 'start' ? this.start : delta.start
-            var zone = this.getZone(calcstart)
+			var calcstart = this.alter === 'start' ? this.start : delta.start;
+			var zone = this.getZone(calcstart);
 
-            // if start, size or offset change, update scroll position.
-            if (this.alter && ~['start', 'size', 'offset'].indexOf(this.alter)) {
-                var scrollTop = this.alter === 'offset'
-                    ? this.offset : this.variable
-                        ? this.getVarOffset(zone.isLast ? delta.total : zone.start)
-                        : zone.isLast && (delta.total - calcstart <= this.remain)
-                            ? delta.total * this.size : calcstart * this.size
+			// if start, size or offset change, update scroll position.
+			if (this.alter && ~[ 'start', 'size', 'offset' ].indexOf(this.alter)) {
+				var scrollTop =
+					this.alter === 'offset'
+						? this.offset
+						: this.variable
+							? this.getVarOffset(zone.isLast ? delta.total : zone.start)
+							: zone.isLast && delta.total - calcstart <= this.remain
+								? delta.total * this.size
+								: calcstart * this.size;
 
-                this.$nextTick(this.setScrollTop.bind(this, scrollTop))
-            }
+				this.$nextTick(this.setScrollTop.bind(this, scrollTop));
+			}
 
-            // if points out difference, force update once again.
-            if (calcstart !== zone.start || delta.end !== zone.end || this.alter) {
-                this.alter = ''
-                delta.end = zone.end
-                delta.start = zone.start
-                this.forceRender()
-            }
-        },
+			// if points out difference, force update once again.
+			if (calcstart !== zone.start || delta.end !== zone.end || this.alter) {
+				this.alter = '';
+				delta.end = zone.end;
+				delta.start = zone.start;
+				this.forceRender();
+			}
+		},
 
-        render: function (h) {
-            var list = this.filter()
-            var delta = this.delta
-            var dbc = this.debounce
-
-            return h(this.rtag, {
-                'ref': 'vsl',
-                'style': {
-                    'display': 'block',
-                    'overflow-y': 'auto',
-                    'height': this.size * this.remain + 'px'
-                },
-                'on': {
-                    '&scroll': dbc ? _debounce(this.onScroll.bind(this), dbc) : this.onScroll
-                }
-            }, [
-                h(this.wtag, {
-                    'style': {
-                        'display': 'block',
-                        'padding-top': delta.paddingTop + 'px',
-                        'padding-bottom': delta.paddingBottom + 'px'
-                    },
-                    'class': this.wclass
-                }, list)
-            ])
-        }
-    })
-})
+		render: function (h) {
+			var list = this.filter();
+			var delta = this.delta;
+			var dbc = this.debounce;
+			return h(
+				this.rtag,
+				{
+					ref: 'vsl',
+					style: {
+						display: 'block',
+						'overflow-y': 'auto',
+						height: this.size * this.remain + 'px'
+					},
+					on: {
+						'&scroll': dbc ? _debounce(this.onScroll.bind(this), dbc) : this.onScroll
+					}
+				},
+				[
+					h(
+						this.wtag,
+						{
+							style: {
+								display: 'block',
+								'padding-top': delta.paddingTop + 'px',
+								'padding-bottom': delta.paddingBottom + 'px'
+							},
+							class: this.wclass,
+							role: 'group'
+						},
+						list
+					)
+				]
+			);
+		}
+	});
+});

--- a/index.js
+++ b/index.js
@@ -1,466 +1,466 @@
 (function (root, factory) {
-	var namespace = 'VirtualScrollList';
+    var namespace = 'VirtualScrollList'
 	/* istanbul ignore next */
 	if (typeof exports === 'object' && typeof module === 'object') {
-		module.exports = factory(namespace, require('vue'));
+        module.exports = factory(namespace, require('vue'))
 	} else if (typeof define === 'function' && define.amd) {
-		define([ 'vue' ], factory.bind(root, namespace));
+        define([ 'vue' ], factory.bind(root, namespace))
 	} else if (typeof exports === 'object') {
-		exports[namespace] = factory(namespace, require('vue'));
+        exports[namespace] = factory(namespace, require('vue'))
 	} else {
-		root[namespace] = factory(namespace, root['Vue']);
+        root[namespace] = factory(namespace, root['Vue'])
 	}
 })(this, function (namespace, Vue2) {
-	/* istanbul ignore next */
-	if (typeof Vue2 === 'object' && typeof Vue2.default === 'function') {
-		Vue2 = Vue2.default;
+    /* istanbul ignore next */
+    if (typeof Vue2 === 'object' && typeof Vue2.default === 'function') {
+        Vue2 = Vue2.default
 	}
 
-	/* istanbul ignore next */
-	var _debounce = function (func, wait, immediate) {
-		var timeout;
+    /* istanbul ignore next */
+    var _debounce = function (func, wait, immediate) {
+        var timeout
 		return function () {
-			var context = this;
-			var args = arguments;
+            var context = this
+			var args = arguments
 			var later = function () {
-				timeout = null;
+                timeout = null
 				if (!immediate) {
-					func.apply(context, args);
+                    func.apply(context, args)
 				}
-			};
-			var callNow = immediate && !timeout;
-			clearTimeout(timeout);
-			timeout = setTimeout(later, wait);
+            }
+			var callNow = immediate && !timeout
+			clearTimeout(timeout)
+			timeout = setTimeout(later, wait)
 			if (callNow) {
-				func.apply(context, args);
+                func.apply(context, args)
 			}
-		};
+        }
 	};
 
-	return Vue2.component(namespace, {
-		props: {
-			size: { type: Number, required: true },
-			remain: { type: Number, required: true },
-			rtag: { type: String, default: 'div' },
-			wtag: { type: String, default: 'div' },
-			wclass: { type: String, default: '' },
-			start: { type: Number, default: 0 },
-			offset: { type: Number, default: 0 },
-			variable: [ Function, Boolean ],
-			bench: Number,
-			debounce: Number,
-			totop: Function,
-			tobottom: Function,
-			onscroll: Function,
-			item: { type: Object },
-			itemcount: { type: Number },
-			itemprops: { type: Function }
-		},
+    return Vue2.component(namespace, {
+        props: {
+            size: { type: Number, required: true },
+            remain: { type: Number, required: true },
+            rtag: { type: String, default: 'div' },
+            wtag: { type: String, default: 'div' },
+            wclass: { type: String, default: '' },
+            start: { type: Number, default: 0 },
+            offset: { type: Number, default: 0 },
+            variable: [ Function, Boolean ],
+            bench: Number,
+            debounce: Number,
+            totop: Function,
+            tobottom: Function,
+            onscroll: Function,
+            item: { type: Object },
+            itemcount: { type: Number },
+            itemprops: { type: Function }
+        },
 
-		created: function () {
-			var start = this.start >= this.remain ? this.start : 0;
-			var keeps = this.remain + (this.bench || this.remain);
+        created: function () {
+            var start = this.start >= this.remain ? this.start : 0
+			var keeps = this.remain + (this.bench || this.remain)
 
 			this.delta = {
-				direction: '', // current scroll direction, D: down, U: up.
-				scrollTop: 0, // current scroll top, use to direction.
-				start: start, // start index.
-				end: start + keeps - 1, // end index.
-				keeps: keeps, // nums keeping in real dom.
-				total: 0, // all items count, update in filter.
-				offsetAll: 0, // cache all the scrollable offset.
-				paddingTop: 0, // container wrapper real padding-top.
-				paddingBottom: 0, // container wrapper real padding-bottom.
-				varCache: {}, // object to cache variable index height and scroll offset.
-				varAverSize: 0, // average/estimate item height before variable be calculated.
-				varLastCalcIndex: 0 // last calculated variable height/offset index, always increase.
-			};
+                direction: '', // current scroll direction, D: down, U: up.
+                scrollTop: 0, // current scroll top, use to direction.
+                start: start, // start index.
+                end: start + keeps - 1, // end index.
+                keeps: keeps, // nums keeping in real dom.
+                total: 0, // all items count, update in filter.
+                offsetAll: 0, // cache all the scrollable offset.
+                paddingTop: 0, // container wrapper real padding-top.
+                paddingBottom: 0, // container wrapper real padding-bottom.
+                varCache: {}, // object to cache variable index height and scroll offset.
+                varAverSize: 0, // average/estimate item height before variable be calculated.
+                varLastCalcIndex: 0 // last calculated variable height/offset index, always increase.
+            }
 		},
 
-		// use alter to identify which prop change.
-		watch: {
-			size: function () {
-				this.alter = 'size';
+        // use alter to identify which prop change.
+        watch: {
+            size: function () {
+                this.alter = 'size'
 			},
-			remain: function () {
-				this.alter = 'remain';
+            remain: function () {
+                this.alter = 'remain'
 			},
-			bench: function () {
-				this.alter = 'bench';
-				this.itemModeForceRender();
+            bench: function () {
+                this.alter = 'bench'
+				this.itemModeForceRender()
 			},
-			start: function () {
-				this.alter = 'start';
-				this.itemModeForceRender();
+            start: function () {
+                this.alter = 'start'
+				this.itemModeForceRender()
 			},
-			offset: function () {
-				this.alter = 'offset';
-				this.itemModeForceRender();
+            offset: function () {
+                this.alter = 'offset'
+				this.itemModeForceRender()
 			},
-			itemcount: function () {
-				this.alter = 'itemcount';
-				this.itemModeForceRender();
+            itemcount: function () {
+                this.alter = 'itemcount'
+				this.itemModeForceRender()
 			}
-		},
+        },
 
-		methods: {
-			onScroll: function (e) {
-				var delta = this.delta;
-				var vsl = this.$refs.vsl;
-				var offset = (vsl.$el || vsl).scrollTop || 0;
+        methods: {
+            onScroll: function (e) {
+                var delta = this.delta
+				var vsl = this.$refs.vsl
+				var offset = (vsl.$el || vsl).scrollTop || 0
 
-				delta.direction = offset > delta.scrollTop ? 'D' : 'U';
-				delta.scrollTop = offset;
+				delta.direction = offset > delta.scrollTop ? 'D' : 'U'
+				delta.scrollTop = offset
 
 				if (delta.total > delta.keeps) {
-					this.updateZone(offset);
+                    this.updateZone(offset)
 				} else {
-					delta.end = delta.total - 1;
+                    delta.end = delta.total - 1
 				}
 
-				var offsetAll = delta.offsetAll;
+                var offsetAll = delta.offsetAll
 				if (this.onscroll) {
-					this.onscroll(e, {
-						offset: offset,
-						offsetAll: offsetAll,
-						start: delta.start,
-						end: delta.end
-					});
+                    this.onscroll(e, {
+                        offset: offset,
+                        offsetAll: offsetAll,
+                        start: delta.start,
+                        end: delta.end
+                    })
 				}
 
-				if (!offset && delta.total) {
-					this.fireEvent('totop');
+                if (!offset && delta.total) {
+                    this.fireEvent('totop')
 				}
 
-				if (offset >= offsetAll) {
-					this.fireEvent('tobottom');
+                if (offset >= offsetAll) {
+                    this.fireEvent('tobottom')
 				}
-			},
+            },
 
-			// update render zone by scroll offset.
-			updateZone: function (offset) {
-				var delta = this.delta;
-				var overs = this.variable ? this.getVarOvers(offset) : Math.floor(offset / this.size);
+            // update render zone by scroll offset.
+            updateZone: function (offset) {
+                var delta = this.delta
+				var overs = this.variable ? this.getVarOvers(offset) : Math.floor(offset / this.size)
 
 				// if scroll up, we'd better decrease it's numbers.
 				if (delta.direction === 'U') {
-					overs = overs - this.remain + 1;
+                    overs = overs - this.remain + 1
 				}
 
-				var zone = this.getZone(overs);
-				var bench = this.bench || this.remain;
+                var zone = this.getZone(overs)
+				var bench = this.bench || this.remain
 
 				// for better performance, if scroll pass items within now bench, do not update.
 				// and if overs is going to reach last item, we should render next zone immediately.
-				var shouldRenderNextZone = Math.abs(overs - delta.start - bench) === 1;
+				var shouldRenderNextZone = Math.abs(overs - delta.start - bench) === 1
 				if (!shouldRenderNextZone && overs - delta.start <= bench && !zone.isLast && overs > delta.start) {
-					return;
+                    return
 				}
 
-				// we'd better make sure forceRender calls as less as possible.
-				if (shouldRenderNextZone || zone.start !== delta.start || zone.end !== delta.end) {
-					delta.end = zone.end;
-					delta.start = zone.start;
-					this.forceRender();
+                // we'd better make sure forceRender calls as less as possible.
+                if (shouldRenderNextZone || zone.start !== delta.start || zone.end !== delta.end) {
+                    delta.end = zone.end
+					delta.start = zone.start
+					this.forceRender()
 				}
-			},
+            },
 
-			// return the right zone info base on `start/index`.
-			getZone: function (index) {
-				var start, end;
-				var delta = this.delta;
+            // return the right zone info base on `start/index`.
+            getZone: function (index) {
+                var start, end
+				var delta = this.delta
 
-				index = parseInt(index, 10);
-				index = Math.max(0, index);
+				index = parseInt(index, 10)
+				index = Math.max(0, index)
 
-				var lastStart = delta.total - delta.keeps;
-				var isLast = (index <= delta.total && index >= lastStart) || index > delta.total;
+				var lastStart = delta.total - delta.keeps
+				var isLast = (index <= delta.total && index >= lastStart) || index > delta.total
 				if (isLast) {
-					end = delta.total - 1;
-					start = Math.max(0, lastStart);
+                    end = delta.total - 1
+					start = Math.max(0, lastStart)
 				} else {
-					start = index;
-					end = start + delta.keeps - 1;
+                    start = index
+					end = start + delta.keeps - 1
 				}
 
-				return {
-					end: end,
-					start: start,
-					isLast: isLast
-				};
+                return {
+                    end: end,
+                    start: start,
+                    isLast: isLast
+                }
 			},
 
-			// public method, force render ui list if we needed.
-			// call this before the next repaint to get better performance.
-			forceRender: function () {
-				var that = this;
+            // public method, force render ui list if we needed.
+            // call this before the next repaint to get better performance.
+            forceRender: function () {
+                var that = this
 				window.requestAnimationFrame(function () {
-					that.$forceUpdate();
-				});
+                    that.$forceUpdate()
+				})
 			},
 
-			// force render ui if using item mode.
-			itemModeForceRender: function () {
-				if (this.item) {
-					this.forceRender();
+            // force render ui if using item mode.
+            itemModeForceRender: function () {
+                if (this.item) {
+                    this.forceRender()
 				}
-			},
+            },
 
-			// return the scroll passed items count in variable.
-			getVarOvers: function (offset) {
-				var low = 0;
-				var middle = 0;
-				var middleOffset = 0;
-				var delta = this.delta;
-				var high = delta.total;
+            // return the scroll passed items count in variable.
+            getVarOvers: function (offset) {
+                var low = 0
+				var middle = 0
+				var middleOffset = 0
+				var delta = this.delta
+				var high = delta.total
 
 				while (low <= high) {
-					middle = low + Math.floor((high - low) / 2);
-					middleOffset = this.getVarOffset(middle);
+                    middle = low + Math.floor((high - low) / 2)
+					middleOffset = this.getVarOffset(middle)
 
 					// calculate the average variable height at first binary search.
 					if (!delta.varAverSize) {
-						delta.varAverSize = Math.floor(middleOffset / middle);
+                        delta.varAverSize = Math.floor(middleOffset / middle)
 					}
 
-					if (middleOffset === offset) {
-						return middle;
+                    if (middleOffset === offset) {
+                        return middle
 					} else if (middleOffset < offset) {
-						low = middle + 1;
+                        low = middle + 1
 					} else if (middleOffset > offset) {
-						high = middle - 1;
+                        high = middle - 1
 					}
-				}
+                }
 
-				return low > 0 ? --low : 0;
+                return low > 0 ? --low : 0
 			},
 
-			// return a variable scroll offset from given index.
-			getVarOffset: function (index, nocache) {
-				var delta = this.delta;
-				var cache = delta.varCache[index];
+            // return a variable scroll offset from given index.
+            getVarOffset: function (index, nocache) {
+                var delta = this.delta
+				var cache = delta.varCache[index]
 
 				if (!nocache && cache) {
-					return cache.offset;
+                    return cache.offset
 				}
 
-				var offset = 0;
+                var offset = 0
 				for (var i = 0; i < index; i++) {
-					var size = this.getVarSize(i, nocache);
+                    var size = this.getVarSize(i, nocache)
 					delta.varCache[i] = {
-						size: size,
-						offset: offset
-					};
-					offset += size;
+                        size: size,
+                        offset: offset
+                    }
+					offset += size
 				}
 
-				delta.varLastCalcIndex = Math.max(delta.varLastCalcIndex, index - 1);
-				delta.varLastCalcIndex = Math.min(delta.varLastCalcIndex, delta.total - 1);
+                delta.varLastCalcIndex = Math.max(delta.varLastCalcIndex, index - 1)
+				delta.varLastCalcIndex = Math.min(delta.varLastCalcIndex, delta.total - 1)
 
-				return offset;
+				return offset
 			},
 
-			// return a variable size (height) from given index.
-			getVarSize: function (index, nocache) {
-				var cache = this.delta.varCache[index];
+            // return a variable size (height) from given index.
+            getVarSize: function (index, nocache) {
+                var cache = this.delta.varCache[index]
 				if (!nocache && cache) {
-					return cache.size;
+                    return cache.size
 				}
 
-				if (typeof this.variable === 'function') {
-					return this.variable(index) || 0;
+                if (typeof this.variable === 'function') {
+                    return this.variable(index) || 0
 				} else {
-					// when using item, it can only get current components height,
-					// need to be enhanced, or consider using variable-function instead
-					var slot = this.item
-						? this.$children[index] ? this.$children[index].$vnode : null
-						: this.$slots.default[index];
+                    // when using item, it can only get current components height,
+                    // need to be enhanced, or consider using variable-function instead
+                    var slot = this.item
+                        ? this.$children[index] ? this.$children[index].$vnode : null
+                        : this.$slots.default[index]
 
-					var style = slot && slot.data && slot.data.style;
+					var style = slot && slot.data && slot.data.style
 					if (style && style.height) {
-						var shm = style.height.match(/^(.*)px$/);
-						return (shm && +shm[1]) || 0;
+                        var shm = style.height.match(/^(.*)px$/)
+						return (shm && +shm[1]) || 0
 					}
-				}
-				return 0;
+                }
+                return 0
 			},
 
-			// return the variable paddingTop base current zone.
-			// @todo: if set a large `start` before variable was calculated,
-			// here will also case too much offset calculate when list is very large,
-			// consider use estimate paddingTop in this case just like `getVarPaddingBottom`.
-			getVarPaddingTop: function () {
-				return this.getVarOffset(this.delta.start);
+            // return the variable paddingTop base current zone.
+            // @todo: if set a large `start` before variable was calculated,
+            // here will also case too much offset calculate when list is very large,
+            // consider use estimate paddingTop in this case just like `getVarPaddingBottom`.
+            getVarPaddingTop: function () {
+                return this.getVarOffset(this.delta.start)
 			},
 
-			// return the variable paddingBottom base current zone.
-			getVarPaddingBottom: function () {
-				var delta = this.delta;
-				var last = delta.total - 1;
+            // return the variable paddingBottom base current zone.
+            getVarPaddingBottom: function () {
+                var delta = this.delta
+				var last = delta.total - 1
 				if (delta.total - delta.end <= delta.keeps || delta.varLastCalcIndex === last) {
-					return this.getVarOffset(last) - this.getVarOffset(delta.end);
+                    return this.getVarOffset(last) - this.getVarOffset(delta.end)
 				} else {
-					// if unreached last zone or uncalculate real behind offset
-					// return the estimate paddingBottom avoid too much calculate.
-					return (delta.total - delta.end) * (delta.varAverSize || this.size);
+                    // if unreached last zone or uncalculate real behind offset
+                    // return the estimate paddingBottom avoid too much calculate.
+                    return (delta.total - delta.end) * (delta.varAverSize || this.size)
 				}
-			},
+            },
 
-			// retun the variable all heights use to judge reach bottom.
-			getVarAllHeight: function () {
-				var delta = this.delta;
+            // retun the variable all heights use to judge reach bottom.
+            getVarAllHeight: function () {
+                var delta = this.delta
 				if (delta.total - delta.end <= delta.keeps || delta.varLastCalcIndex === delta.total - 1) {
-					return this.getVarOffset(delta.total);
+                    return this.getVarOffset(delta.total)
 				} else {
-					return (
-						this.getVarOffset(delta.start) + (delta.total - delta.end) * (delta.varAverSize || this.size)
-					);
+                    return (
+                        this.getVarOffset(delta.start) + (delta.total - delta.end) * (delta.varAverSize || this.size)
+                    )
 				}
+            },
+
+            // public method, allow the parent update variable by index.
+            updateVariable: function (index) {
+                // clear/update all the offfsets and heights ahead of index.
+                this.getVarOffset(index, true)
 			},
 
-			// public method, allow the parent update variable by index.
-			updateVariable: function (index) {
-				// clear/update all the offfsets and heights ahead of index.
-				this.getVarOffset(index, true);
-			},
-
-			// trigger a props event on parent.
-			fireEvent: function (event) {
-				if (this[event]) {
-					this[event]();
+            // trigger a props event on parent.
+            fireEvent: function (event) {
+                if (this[event]) {
+                    this[event]()
 				}
-			},
+            },
 
-			// set manual scroll top.
-			setScrollTop: function (scrollTop) {
-				var vsl = this.$refs.vsl;
+            // set manual scroll top.
+            setScrollTop: function (scrollTop) {
+                var vsl = this.$refs.vsl
 				if (vsl) {
-					(vsl.$el || vsl).scrollTop = scrollTop;
+                    (vsl.$el || vsl).scrollTop = scrollTop
 				}
-			},
+            },
 
-			// filter the shown items base on `start` and `end`.
-			filter: function () {
-				var delta = this.delta;
-				var slots = this.$slots.default;
+            // filter the shown items base on `start` and `end`.
+            filter: function () {
+                var delta = this.delta
+				var slots = this.$slots.default
 
 				// item mode shoud judge from items prop.
 				if (this.item) {
-					delta.total = this.itemcount;
+                    delta.total = this.itemcount
 				} else {
-					if (!slots) {
-						slots = [];
-						delta.start = 0;
+                    if (!slots) {
+                        slots = []
+						delta.start = 0
 					}
-					delta.total = slots.length;
+                    delta.total = slots.length
 				}
 
-				var paddingTop, paddingBottom, allHeight;
-				var hasPadding = delta.total > delta.keeps;
+                var paddingTop, paddingBottom, allHeight
+				var hasPadding = delta.total > delta.keeps
 
 				if (this.variable) {
-					allHeight = this.getVarAllHeight();
-					paddingTop = hasPadding ? this.getVarPaddingTop() : 0;
-					paddingBottom = hasPadding ? this.getVarPaddingBottom() : 0;
+                    allHeight = this.getVarAllHeight()
+					paddingTop = hasPadding ? this.getVarPaddingTop() : 0
+					paddingBottom = hasPadding ? this.getVarPaddingBottom() : 0
 				} else {
-					allHeight = this.size * delta.total;
-					paddingTop = this.size * (hasPadding ? delta.start : 0);
-					paddingBottom = this.size * (hasPadding ? delta.total - delta.keeps : 0) - paddingTop;
+                    allHeight = this.size * delta.total
+					paddingTop = this.size * (hasPadding ? delta.start : 0)
+					paddingBottom = this.size * (hasPadding ? delta.total - delta.keeps : 0) - paddingTop
 				}
 
-				if (paddingBottom < this.size) {
-					paddingBottom = 0;
+                if (paddingBottom < this.size) {
+                    paddingBottom = 0
 				}
 
-				delta.paddingTop = paddingTop;
-				delta.paddingBottom = paddingBottom;
-				delta.offsetAll = allHeight - this.size * this.remain;
+                delta.paddingTop = paddingTop
+				delta.paddingBottom = paddingBottom
+				delta.offsetAll = allHeight - this.size * this.remain
 
-				var targets = [];
+				var targets = []
 				for (var i = delta.start; i <= Math.ceil(delta.end); i++) {
-					// create vnode, using custom attrs binder.
-					var slot =
-						this.item && this.itemprops ? this.$createElement(this.item, this.itemprops(i)) : slots[i];
-					targets.push(slot);
+                    // create vnode, using custom attrs binder.
+                    var slot =
+						this.item && this.itemprops ? this.$createElement(this.item, this.itemprops(i)) : slots[i]
+					targets.push(slot)
 				}
 
-				return targets;
+                return targets
 			}
-		},
+        },
 
-		mounted: function () {
-			if (this.start) {
-				var start = this.getZone(this.start).start;
-				this.setScrollTop(this.variable ? this.getVarOffset(start) : start * this.size);
+        mounted: function () {
+            if (this.start) {
+                var start = this.getZone(this.start).start
+				this.setScrollTop(this.variable ? this.getVarOffset(start) : start * this.size)
 			} else if (this.offset) {
-				this.setScrollTop(this.offset);
+                this.setScrollTop(this.offset)
 			}
-		},
+        },
 
-		// check if delta should update when prorps change.
-		beforeUpdate: function () {
-			var delta = this.delta;
-			delta.keeps = this.remain + (this.bench || this.remain);
+        // check if delta should update when prorps change.
+        beforeUpdate: function () {
+            var delta = this.delta
+			delta.keeps = this.remain + (this.bench || this.remain)
 
-			var calcstart = this.alter === 'start' ? this.start : delta.start;
-			var zone = this.getZone(calcstart);
+			var calcstart = this.alter === 'start' ? this.start : delta.start
+			var zone = this.getZone(calcstart)
 
 			// if start, size or offset change, update scroll position.
 			if (this.alter && ~[ 'start', 'size', 'offset' ].indexOf(this.alter)) {
-				var scrollTop =
+                var scrollTop =
 					this.alter === 'offset'
-						? this.offset
-						: this.variable
-							? this.getVarOffset(zone.isLast ? delta.total : zone.start)
-							: zone.isLast && delta.total - calcstart <= this.remain
-								? delta.total * this.size
-								: calcstart * this.size;
+					    ? this.offset
+					    : this.variable
+					        ? this.getVarOffset(zone.isLast ? delta.total : zone.start)
+					        : zone.isLast && delta.total - calcstart <= this.remain
+					            ? delta.total * this.size
+					            : calcstart * this.size
 
-				this.$nextTick(this.setScrollTop.bind(this, scrollTop));
+				this.$nextTick(this.setScrollTop.bind(this, scrollTop))
 			}
 
-			// if points out difference, force update once again.
-			if (calcstart !== zone.start || delta.end !== zone.end || this.alter) {
-				this.alter = '';
-				delta.end = zone.end;
-				delta.start = zone.start;
-				this.forceRender();
+            // if points out difference, force update once again.
+            if (calcstart !== zone.start || delta.end !== zone.end || this.alter) {
+                this.alter = ''
+				delta.end = zone.end
+				delta.start = zone.start
+				this.forceRender()
 			}
-		},
+        },
 
-		render: function (h) {
-			var list = this.filter();
-			var delta = this.delta;
-			var dbc = this.debounce;
+        render: function (h) {
+            var list = this.filter()
+			var delta = this.delta
+			var dbc = this.debounce
 			return h(
-				this.rtag,
-				{
-					ref: 'vsl',
-					style: {
-						display: 'block',
-						'overflow-y': 'auto',
-						height: this.size * this.remain + 'px'
-					},
-					on: {
-						'&scroll': dbc ? _debounce(this.onScroll.bind(this), dbc) : this.onScroll
-					}
-				},
-				[
-					h(
-						this.wtag,
-						{
-							style: {
-								display: 'block',
-								'padding-top': delta.paddingTop + 'px',
-								'padding-bottom': delta.paddingBottom + 'px'
-							},
-							class: this.wclass,
-							role: 'group'
-						},
-						list
-					)
-				]
-			);
+                this.rtag,
+                {
+                    ref: 'vsl',
+                    style: {
+                        display: 'block',
+                        'overflow-y': 'auto',
+                        height: this.size * this.remain + 'px'
+                    },
+                    on: {
+                        '&scroll': dbc ? _debounce(this.onScroll.bind(this), dbc) : this.onScroll
+                    }
+                },
+                [
+                    h(
+                        this.wtag,
+                        {
+                            style: {
+                                display: 'block',
+                                'padding-top': delta.paddingTop + 'px',
+                                'padding-bottom': delta.paddingBottom + 'px'
+                            },
+                            class: this.wclass,
+                            role: 'group'
+                        },
+                        list
+                    )
+                ]
+            )
 		}
-	});
-});
+    })
+})

--- a/index.js
+++ b/index.js
@@ -1,41 +1,41 @@
 (function (root, factory) {
     var namespace = 'VirtualScrollList'
-	/* istanbul ignore next */
-	if (typeof exports === 'object' && typeof module === 'object') {
+    /* istanbul ignore next */
+    if (typeof exports === 'object' && typeof module === 'object') {
         module.exports = factory(namespace, require('vue'))
-	} else if (typeof define === 'function' && define.amd) {
-        define([ 'vue' ], factory.bind(root, namespace))
-	} else if (typeof exports === 'object') {
+    } else if (typeof define === 'function' && define.amd) {
+        define(['vue'], factory.bind(root, namespace))
+    } else if (typeof exports === 'object') {
         exports[namespace] = factory(namespace, require('vue'))
-	} else {
+    } else {
         root[namespace] = factory(namespace, root['Vue'])
-	}
+    }
 })(this, function (namespace, Vue2) {
     /* istanbul ignore next */
     if (typeof Vue2 === 'object' && typeof Vue2.default === 'function') {
         Vue2 = Vue2.default
-	}
+    }
 
     /* istanbul ignore next */
     var _debounce = function (func, wait, immediate) {
         var timeout
-		return function () {
+        return function () {
             var context = this
-			var args = arguments
-			var later = function () {
+            var args = arguments
+            var later = function () {
                 timeout = null
-				if (!immediate) {
+                if (!immediate) {
                     func.apply(context, args)
-				}
+                }
             }
-			var callNow = immediate && !timeout
-			clearTimeout(timeout)
-			timeout = setTimeout(later, wait)
-			if (callNow) {
+            var callNow = immediate && !timeout
+            clearTimeout(timeout)
+            timeout = setTimeout(later, wait)
+            if (callNow) {
                 func.apply(context, args)
-			}
+            }
         }
-	};
+    }
 
     return Vue2.component(namespace, {
         props: {
@@ -46,7 +46,7 @@
             wclass: { type: String, default: '' },
             start: { type: Number, default: 0 },
             offset: { type: Number, default: 0 },
-            variable: [ Function, Boolean ],
+            variable: [Function, Boolean],
             bench: Number,
             debounce: Number,
             totop: Function,
@@ -59,9 +59,9 @@
 
         created: function () {
             var start = this.start >= this.remain ? this.start : 0
-			var keeps = this.remain + (this.bench || this.remain)
+            var keeps = this.remain + (this.bench || this.remain)
 
-			this.delta = {
+            this.delta = {
                 direction: '', // current scroll direction, D: down, U: up.
                 scrollTop: 0, // current scroll top, use to direction.
                 start: start, // start index.
@@ -75,215 +75,221 @@
                 varAverSize: 0, // average/estimate item height before variable be calculated.
                 varLastCalcIndex: 0 // last calculated variable height/offset index, always increase.
             }
-		},
+        },
 
         // use alter to identify which prop change.
         watch: {
             size: function () {
                 this.alter = 'size'
-			},
+            },
             remain: function () {
                 this.alter = 'remain'
-			},
+            },
             bench: function () {
                 this.alter = 'bench'
-				this.itemModeForceRender()
-			},
+                this.itemModeForceRender()
+            },
             start: function () {
                 this.alter = 'start'
-				this.itemModeForceRender()
-			},
+                this.itemModeForceRender()
+            },
             offset: function () {
                 this.alter = 'offset'
-				this.itemModeForceRender()
-			},
+                this.itemModeForceRender()
+            },
             itemcount: function () {
                 this.alter = 'itemcount'
-				this.itemModeForceRender()
-			}
+                this.itemModeForceRender()
+            }
         },
 
         methods: {
             onScroll: function (e) {
                 var delta = this.delta
-				var vsl = this.$refs.vsl
-				var offset = (vsl.$el || vsl).scrollTop || 0
+                var vsl = this.$refs.vsl
+                var offset = (vsl.$el || vsl).scrollTop || 0
 
-				delta.direction = offset > delta.scrollTop ? 'D' : 'U'
-				delta.scrollTop = offset
+                delta.direction = offset > delta.scrollTop ? 'D' : 'U'
+                delta.scrollTop = offset
 
-				if (delta.total > delta.keeps) {
+                if (delta.total > delta.keeps) {
                     this.updateZone(offset)
-				} else {
+                } else {
                     delta.end = delta.total - 1
-				}
+                }
 
                 var offsetAll = delta.offsetAll
-				if (this.onscroll) {
+                if (this.onscroll) {
                     this.onscroll(e, {
                         offset: offset,
                         offsetAll: offsetAll,
                         start: delta.start,
                         end: delta.end
                     })
-				}
+                }
 
                 if (!offset && delta.total) {
                     this.fireEvent('totop')
-				}
+                }
 
                 if (offset >= offsetAll) {
                     this.fireEvent('tobottom')
-				}
+                }
             },
 
             // update render zone by scroll offset.
             updateZone: function (offset) {
                 var delta = this.delta
-				var overs = this.variable ? this.getVarOvers(offset) : Math.floor(offset / this.size)
+                var overs = this.variable
+                    ? this.getVarOvers(offset)
+                    : Math.floor(offset / this.size)
 
-				// if scroll up, we'd better decrease it's numbers.
-				if (delta.direction === 'U') {
+                // if scroll up, we'd better decrease it's numbers.
+                if (delta.direction === 'U') {
                     overs = overs - this.remain + 1
-				}
+                }
 
                 var zone = this.getZone(overs)
-				var bench = this.bench || this.remain
+                var bench = this.bench || this.remain
 
-				// for better performance, if scroll pass items within now bench, do not update.
-				// and if overs is going to reach last item, we should render next zone immediately.
-				var shouldRenderNextZone = Math.abs(overs - delta.start - bench) === 1
-				if (!shouldRenderNextZone && overs - delta.start <= bench && !zone.isLast && overs > delta.start) {
+                // for better performance, if scroll pass items within now bench, do not update.
+                // and if overs is going to reach last item, we should render next zone immediately.
+                var shouldRenderNextZone = Math.abs(overs - delta.start - bench) === 1
+                if (
+                    !shouldRenderNextZone &&
+                    (overs - delta.start <= bench) &&
+                    !zone.isLast && (overs > delta.start)
+                ) {
                     return
-				}
+                }
 
                 // we'd better make sure forceRender calls as less as possible.
                 if (shouldRenderNextZone || zone.start !== delta.start || zone.end !== delta.end) {
                     delta.end = zone.end
-					delta.start = zone.start
-					this.forceRender()
-				}
+                    delta.start = zone.start
+                    this.forceRender()
+                }
             },
 
             // return the right zone info base on `start/index`.
             getZone: function (index) {
                 var start, end
-				var delta = this.delta
+                var delta = this.delta
 
-				index = parseInt(index, 10)
-				index = Math.max(0, index)
+                index = parseInt(index, 10)
+                index = Math.max(0, index)
 
-				var lastStart = delta.total - delta.keeps
-				var isLast = (index <= delta.total && index >= lastStart) || index > delta.total
-				if (isLast) {
+                var lastStart = delta.total - delta.keeps
+                var isLast = (index <= delta.total && index >= lastStart) || (index > delta.total)
+                if (isLast) {
                     end = delta.total - 1
-					start = Math.max(0, lastStart)
-				} else {
+                    start = Math.max(0, lastStart)
+                } else {
                     start = index
-					end = start + delta.keeps - 1
-				}
+                    end = start + delta.keeps - 1
+                }
 
                 return {
                     end: end,
                     start: start,
                     isLast: isLast
                 }
-			},
+            },
 
             // public method, force render ui list if we needed.
             // call this before the next repaint to get better performance.
             forceRender: function () {
                 var that = this
-				window.requestAnimationFrame(function () {
+                window.requestAnimationFrame(function () {
                     that.$forceUpdate()
-				})
-			},
+                })
+            },
 
             // force render ui if using item mode.
             itemModeForceRender: function () {
                 if (this.item) {
                     this.forceRender()
-				}
+                }
             },
 
             // return the scroll passed items count in variable.
             getVarOvers: function (offset) {
                 var low = 0
-				var middle = 0
-				var middleOffset = 0
-				var delta = this.delta
-				var high = delta.total
+                var middle = 0
+                var middleOffset = 0
+                var delta = this.delta
+                var high = delta.total
 
-				while (low <= high) {
+                while (low <= high) {
                     middle = low + Math.floor((high - low) / 2)
-					middleOffset = this.getVarOffset(middle)
+                    middleOffset = this.getVarOffset(middle)
 
-					// calculate the average variable height at first binary search.
-					if (!delta.varAverSize) {
+                    // calculate the average variable height at first binary search.
+                    if (!delta.varAverSize) {
                         delta.varAverSize = Math.floor(middleOffset / middle)
-					}
+                    }
 
                     if (middleOffset === offset) {
                         return middle
-					} else if (middleOffset < offset) {
+                    } else if (middleOffset < offset) {
                         low = middle + 1
-					} else if (middleOffset > offset) {
+                    } else if (middleOffset > offset) {
                         high = middle - 1
-					}
+                    }
                 }
 
                 return low > 0 ? --low : 0
-			},
+            },
 
             // return a variable scroll offset from given index.
             getVarOffset: function (index, nocache) {
                 var delta = this.delta
-				var cache = delta.varCache[index]
+                var cache = delta.varCache[index]
 
-				if (!nocache && cache) {
+                if (!nocache && cache) {
                     return cache.offset
-				}
+                }
 
                 var offset = 0
-				for (var i = 0; i < index; i++) {
+                for (var i = 0; i < index; i++) {
                     var size = this.getVarSize(i, nocache)
-					delta.varCache[i] = {
+                    delta.varCache[i] = {
                         size: size,
                         offset: offset
                     }
-					offset += size
-				}
+                    offset += size
+                }
 
                 delta.varLastCalcIndex = Math.max(delta.varLastCalcIndex, index - 1)
-				delta.varLastCalcIndex = Math.min(delta.varLastCalcIndex, delta.total - 1)
+                delta.varLastCalcIndex = Math.min(delta.varLastCalcIndex, delta.total - 1)
 
-				return offset
-			},
+                return offset
+            },
 
             // return a variable size (height) from given index.
             getVarSize: function (index, nocache) {
                 var cache = this.delta.varCache[index]
-				if (!nocache && cache) {
+                if (!nocache && cache) {
                     return cache.size
-				}
+                }
 
                 if (typeof this.variable === 'function') {
                     return this.variable(index) || 0
-				} else {
+                } else {
                     // when using item, it can only get current components height,
                     // need to be enhanced, or consider using variable-function instead
                     var slot = this.item
-                        ? this.$children[index] ? this.$children[index].$vnode : null
+                        ? (this.$children[index] ? this.$children[index].$vnode : null)
                         : this.$slots.default[index]
 
-					var style = slot && slot.data && slot.data.style
-					if (style && style.height) {
+                    var style = slot && slot.data && slot.data.style
+                    if (style && style.height) {
                         var shm = style.height.match(/^(.*)px$/)
-						return (shm && +shm[1]) || 0
-					}
+                        return (shm && +shm[1]) || 0
+                    }
                 }
                 return 0
-			},
+            },
 
             // return the variable paddingTop base current zone.
             // @todo: if set a large `start` before variable was calculated,
@@ -291,176 +297,165 @@
             // consider use estimate paddingTop in this case just like `getVarPaddingBottom`.
             getVarPaddingTop: function () {
                 return this.getVarOffset(this.delta.start)
-			},
+            },
 
             // return the variable paddingBottom base current zone.
             getVarPaddingBottom: function () {
                 var delta = this.delta
-				var last = delta.total - 1
-				if (delta.total - delta.end <= delta.keeps || delta.varLastCalcIndex === last) {
+                var last = delta.total - 1
+                if (delta.total - delta.end <= delta.keeps || delta.varLastCalcIndex === last) {
                     return this.getVarOffset(last) - this.getVarOffset(delta.end)
-				} else {
+                } else {
                     // if unreached last zone or uncalculate real behind offset
                     // return the estimate paddingBottom avoid too much calculate.
                     return (delta.total - delta.end) * (delta.varAverSize || this.size)
-				}
+                }
             },
 
             // retun the variable all heights use to judge reach bottom.
             getVarAllHeight: function () {
                 var delta = this.delta
-				if (delta.total - delta.end <= delta.keeps || delta.varLastCalcIndex === delta.total - 1) {
+                if (delta.total - delta.end <= delta.keeps || delta.varLastCalcIndex === delta.total - 1) {
                     return this.getVarOffset(delta.total)
-				} else {
-                    return (
-                        this.getVarOffset(delta.start) + (delta.total - delta.end) * (delta.varAverSize || this.size)
-                    )
-				}
+                } else {
+                    return this.getVarOffset(delta.start) + (delta.total - delta.end) * (delta.varAverSize || this.size)
+                }
             },
 
             // public method, allow the parent update variable by index.
             updateVariable: function (index) {
                 // clear/update all the offfsets and heights ahead of index.
                 this.getVarOffset(index, true)
-			},
+            },
 
             // trigger a props event on parent.
             fireEvent: function (event) {
                 if (this[event]) {
                     this[event]()
-				}
+                }
             },
 
             // set manual scroll top.
             setScrollTop: function (scrollTop) {
                 var vsl = this.$refs.vsl
-				if (vsl) {
+                if (vsl) {
                     (vsl.$el || vsl).scrollTop = scrollTop
-				}
+                }
             },
 
             // filter the shown items base on `start` and `end`.
             filter: function () {
                 var delta = this.delta
-				var slots = this.$slots.default
+                var slots = this.$slots.default
 
-				// item mode shoud judge from items prop.
-				if (this.item) {
+                // item mode shoud judge from items prop.
+                if (this.item) {
                     delta.total = this.itemcount
-				} else {
+                } else {
                     if (!slots) {
                         slots = []
-						delta.start = 0
-					}
+                        delta.start = 0
+                    }
                     delta.total = slots.length
-				}
+                }
 
                 var paddingTop, paddingBottom, allHeight
-				var hasPadding = delta.total > delta.keeps
+                var hasPadding = delta.total > delta.keeps
 
-				if (this.variable) {
+                if (this.variable) {
                     allHeight = this.getVarAllHeight()
-					paddingTop = hasPadding ? this.getVarPaddingTop() : 0
-					paddingBottom = hasPadding ? this.getVarPaddingBottom() : 0
-				} else {
+                    paddingTop = hasPadding ? this.getVarPaddingTop() : 0
+                    paddingBottom = hasPadding ? this.getVarPaddingBottom() : 0
+                } else {
                     allHeight = this.size * delta.total
-					paddingTop = this.size * (hasPadding ? delta.start : 0)
-					paddingBottom = this.size * (hasPadding ? delta.total - delta.keeps : 0) - paddingTop
-				}
+                    paddingTop = this.size * (hasPadding ? delta.start : 0)
+                    paddingBottom = this.size * (hasPadding ? delta.total - delta.keeps : 0) - paddingTop
+                }
 
                 if (paddingBottom < this.size) {
                     paddingBottom = 0
-				}
+                }
 
                 delta.paddingTop = paddingTop
-				delta.paddingBottom = paddingBottom
-				delta.offsetAll = allHeight - this.size * this.remain
+                delta.paddingBottom = paddingBottom
+                delta.offsetAll = allHeight - this.size * this.remain
 
-				var targets = []
-				for (var i = delta.start; i <= Math.ceil(delta.end); i++) {
+                var targets = []
+                for (var i = delta.start; i <= Math.ceil(delta.end); i++) {
                     // create vnode, using custom attrs binder.
-                    var slot =
-						this.item && this.itemprops ? this.$createElement(this.item, this.itemprops(i)) : slots[i]
-					targets.push(slot)
-				}
+                    var slot = this.item && this.itemprops
+                        ? this.$createElement(this.item, this.itemprops(i))
+                        : slots[i]
+                    targets.push(slot)
+                }
 
                 return targets
-			}
+            }
         },
 
         mounted: function () {
             if (this.start) {
                 var start = this.getZone(this.start).start
-				this.setScrollTop(this.variable ? this.getVarOffset(start) : start * this.size)
-			} else if (this.offset) {
+                this.setScrollTop(this.variable ? this.getVarOffset(start) : start * this.size)
+            } else if (this.offset) {
                 this.setScrollTop(this.offset)
-			}
+            }
         },
 
         // check if delta should update when prorps change.
         beforeUpdate: function () {
             var delta = this.delta
-			delta.keeps = this.remain + (this.bench || this.remain)
+            delta.keeps = this.remain + (this.bench || this.remain)
 
-			var calcstart = this.alter === 'start' ? this.start : delta.start
-			var zone = this.getZone(calcstart)
+            var calcstart = this.alter === 'start' ? this.start : delta.start
+            var zone = this.getZone(calcstart)
 
-			// if start, size or offset change, update scroll position.
-			if (this.alter && ~[ 'start', 'size', 'offset' ].indexOf(this.alter)) {
-                var scrollTop =
-					this.alter === 'offset'
-					    ? this.offset
-					    : this.variable
-					        ? this.getVarOffset(zone.isLast ? delta.total : zone.start)
-					        : zone.isLast && delta.total - calcstart <= this.remain
-					            ? delta.total * this.size
-					            : calcstart * this.size
+            // if start, size or offset change, update scroll position.
+            if (this.alter && ~['start', 'size', 'offset'].indexOf(this.alter)) {
+                var scrollTop = this.alter === 'offset'
+                    ? this.offset : this.variable
+                        ? this.getVarOffset(zone.isLast ? delta.total : zone.start)
+                        : zone.isLast && (delta.total - calcstart <= this.remain)
+                            ? delta.total * this.size : calcstart * this.size
 
-				this.$nextTick(this.setScrollTop.bind(this, scrollTop))
-			}
+                this.$nextTick(this.setScrollTop.bind(this, scrollTop))
+            }
 
             // if points out difference, force update once again.
             if (calcstart !== zone.start || delta.end !== zone.end || this.alter) {
                 this.alter = ''
-				delta.end = zone.end
-				delta.start = zone.start
-				this.forceRender()
-			}
+                delta.end = zone.end
+                delta.start = zone.start
+                this.forceRender()
+            }
         },
 
         render: function (h) {
             var list = this.filter()
-			var delta = this.delta
-			var dbc = this.debounce
-			return h(
-                this.rtag,
-                {
-                    ref: 'vsl',
-                    style: {
-                        display: 'block',
-                        'overflow-y': 'auto',
-                        height: this.size * this.remain + 'px'
-                    },
-                    on: {
-                        '&scroll': dbc ? _debounce(this.onScroll.bind(this), dbc) : this.onScroll
-                    }
+            var delta = this.delta
+            var dbc = this.debounce
+
+            return h(this.rtag, {
+                'ref': 'vsl',
+                'style': {
+                    'display': 'block',
+                    'overflow-y': 'auto',
+                    'height': this.size * this.remain + 'px'
                 },
-                [
-                    h(
-                        this.wtag,
-                        {
-                            style: {
-                                display: 'block',
-                                'padding-top': delta.paddingTop + 'px',
-                                'padding-bottom': delta.paddingBottom + 'px'
-                            },
-                            class: this.wclass,
-                            role: 'group'
-                        },
-                        list
-                    )
-                ]
-            )
-		}
+                'on': {
+                    '&scroll': dbc ? _debounce(this.onScroll.bind(this), dbc) : this.onScroll
+                }
+            }, [
+                h(this.wtag, {
+                    'style': {
+                        'display': 'block',
+                        'padding-top': delta.paddingTop + 'px',
+                        'padding-bottom': delta.paddingBottom + 'px'
+                    },
+                    'class': this.wclass,
+                    'role': 'group'
+                }, list)
+            ])
+        }
     })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-virtual-scroll-list",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4554,12 +4554,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4574,17 +4576,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4701,7 +4706,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4713,6 +4719,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4727,6 +4734,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4734,12 +4742,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4758,6 +4768,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4838,7 +4849,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4850,6 +4862,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4971,6 +4984,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",


### PR DESCRIPTION
With the group on the wrapper adding a roll of 'list' the the  virtual-scroll-list, and list-item on the list elements. Generated code would follow the ARIA authoring guidelines for a list.
```html
    <virtual-list :size="40" :remain="8" class="scroller" role="list"
      inherit
    >
        <list-item
          role="listitem"
          :aria-setsize="items.length"
          :aria-posinset="index + 1"
          v-for="(item, index) of items"
          :key="item.id"       
          :item="item"
        >
         </list-item>
    </virtual-list>