### PR TITLE
Do not add each item data as props but wrap it in a single data prop.

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -530,7 +530,9 @@
       return h(this.tag, {
         role: 'item'
       }, [h(this.component, {
-        props: this.source
+        props: {
+          data: this.source
+        }
       })]);
     }
   }); // wrapping for slot.

--- a/src/item.js
+++ b/src/item.js
@@ -58,7 +58,7 @@ export const Item = Vue.component('virtual-list-item', {
     return h(this.tag, {
       role: 'item'
     }, [h(this.component, {
-      props: this.source
+      props: { data: this.source }
     })])
   }
 })


### PR DESCRIPTION
**What kind of this PR?**

Developper experience improvement.

**Other information:**

In his question, #176 @MOSMekawy asks how to pass props to the list item component.

This is true that using list of complex objects make it a pain to use. Indeed, every info if the source object is passed as an indivual prop in the component so you have to list them all. For various reasons, this can be fastidious to declare and manipulate.

In this pull request, I have transmitted the whole data-source object under the "data" props.
So you can conveniently declare one Object props in your listed component and use it as you normally do.
Fetching a list of *something* from an API and listing it (and using it in a view component within the list) is then made simpler.