### PR TITLE
Using dataSource[dataKey] leads to false results

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -224,7 +224,7 @@ const VirtualList = Vue.component('virtual-list', {
       for (let index = start; index <= end; index++) {
         const dataSource = dataSources[index]
         if (dataSource) {
-          if(dataSource.hasOwnProperty(dataKey)) {
+          if(Object.prototype.hasOwnProperty.call(dataSource, dataKey)) {
             slots.push(h(Item, {
               props: {
                 index,

--- a/src/index.js
+++ b/src/index.js
@@ -224,7 +224,7 @@ const VirtualList = Vue.component('virtual-list', {
       for (let index = start; index <= end; index++) {
         const dataSource = dataSources[index]
         if (dataSource) {
-          if (dataSource[dataKey]) {
+          if(dataSource.hasOwnProperty(dataKey)) {
             slots.push(h(Item, {
               props: {
                 index,


### PR DESCRIPTION
Using `dataSource[dataKey]` has 2 issues:
1. It searches the complete prototype chain (which is unefficient)
2. If the resolved value is `0` or `false` the result is `false` (which isn't intended)

Example:
dataKey is 'id', it's value is zero:
e.g.
{
   id: 0
}

So better to be explicit here, e.g. 👍 
` if(dataSource.hasOwnProperty(dataKey)) `

**What kind of this PR?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Build-related changes
- [ ] Other, please describe:

**Other information:**
