### PR TITLE
add key for rendering items

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -269,6 +269,7 @@ const VirtualList = Vue.component('virtual-list', {
         if (dataSource) {
           if (Object.prototype.hasOwnProperty.call(dataSource, dataKey)) {
             slots.push(h(Item, {
+              key: dataSource[dataKey],
               props: {
                 index,
                 tag: itemTag,


### PR DESCRIPTION
it will increase speed of VNode-Dom comparison and patch

for example for list of images when new slots added to the list only these images will requested from server (at this moment all 30 will be requested) also no visual glitches when this images downloaded (rerender from previous image to new)
