### PR TITLE
Fix for issue #206(Occasional blank rows)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -238,7 +238,7 @@ const VirtualList = Vue.component('virtual-list', {
       const scrollSize = this.getScrollSize()
 
       // iOS scroll-spring-back behavior will make direction mistake
-      if (offset < 0 || (offset + clientSize > scrollSize) || !scrollSize) {
+      if (offset < 0 || !scrollSize) {
         return
       }
 


### PR DESCRIPTION
Removed 'offset + clientSize > scrollSize' because some browsers miscaculates variables when scrollToBottom method is used.
