### PR TITLE
Response to update when `keeps` changes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,11 @@ const VirtualList = Vue.component('virtual-list', {
       this.virtual.handleDataSourcesChange()
     },
 
+    keeps (newValue) {
+      this.virtual.updateParam('keeps', newValue);
+      this.virtual.handleSlotSizeChange();
+    },
+
     start (newValue) {
       this.scrollToIndex(newValue)
     },


### PR DESCRIPTION
**What kind of this PR?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Build-related changes
- [ ] Other, please describe:

**Other information:**
When the width or height of the outer container changes, the value of props `keeps` will also change, and then need to re-render at this time.