### PR TITLE
Calculate correct average size

### DIFF
--- a/src/virtual.js
+++ b/src/virtual.js
@@ -106,7 +106,7 @@ export default class Virtual {
     // calculate the average size only in the first range
     if (this.calcType !== CALC_TYPE.FIXED && typeof this.firstRangeTotalSize !== 'undefined') {
       if (this.sizes.size < Math.min(this.param.keeps, this.param.uniqueIds.length)) {
-        this.firstRangeTotalSize = this.firstRangeTotalSize + size
+        this.firstRangeTotalSize = [...this.sizes.values()].reduce((acc, val) => acc + val, 0)
         this.firstRangeAverageSize = Math.round(this.firstRangeTotalSize / this.sizes.size)
       } else {
         // it's done using


### PR DESCRIPTION
**What kind of this PR?**

- [x] Bugfix

**Other information:**

firstRangeAverageSize is calculated wrong when the first items of the first range have the same size and the following item has a different size. firstRangeTotalSize is then not the sum of all sizes in the first range but is calculated starting from the item with the different size on. 

By dividing then firstRangeTotalSize with the total number of sizes gives a wrong estimated size.





