### PR TITLE
wrapStyle should have priority over paddingStyle

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -309,7 +309,7 @@ const VirtualList = Vue.component('virtual-list', {
     const { padFront, padBehind } = this.range
     const { isHorizontal, pageMode, rootTag, wrapTag, wrapClass, wrapStyle, headerTag, headerClass, headerStyle, footerTag, footerClass, footerStyle } = this
     const paddingStyle = { padding: isHorizontal ? `0px ${padBehind}px 0px ${padFront}px` : `${padFront}px 0px ${padBehind}px` }
-    const wrapperStyle = wrapStyle ? Object.assign({}, wrapStyle, paddingStyle) : paddingStyle
+    const wrapperStyle = wrapStyle ? Object.assign({}, paddingStyle, wrapStyle) : paddingStyle
 
     return h(rootTag, {
       ref: 'root',


### PR DESCRIPTION
**What kind of this PR?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Build-related changes
- [ ] Other, please describe:

**Other information:**
Without this patch it is pretty much impossible to have a custom padding for the wrap container like `padding: 4px 2px 1px 0px`.