### PR TITLE
fix: extraProps mutation in item render

### DIFF
--- a/src/item.js
+++ b/src/item.js
@@ -51,9 +51,12 @@ export const Item = Vue.component('virtual-list-item', {
   props: ItemProps,
 
   render (h) {
-    const { tag, component, extraProps = {}, index, scopedSlots = {}, uniqueKey } = this
-    extraProps.source = this.source
-    extraProps.index = index
+    const { tag, component, extraProps = {}, index, source, scopedSlots = {}, uniqueKey } = this;
+    const props = {
+        ...extraProps,
+        source,
+        index,
+    };
 
     return h(tag, {
       key: uniqueKey,
@@ -61,7 +64,7 @@ export const Item = Vue.component('virtual-list-item', {
         role: 'listitem'
       }
     }, [h(component, {
-      props: extraProps,
+      props,
       scopedSlots: scopedSlots
     })])
   }


### PR DESCRIPTION
Prevent adding `source` and `index` to parent's `extraProps` on each item render.

**What kind of this PR?** (check at least one)

- [x] Bugfix
