### PR TITLE
fix scroll from bottom will cause range caculate error

### DIFF
--- a/src/virtual.js
+++ b/src/virtual.js
@@ -11,7 +11,7 @@ const CALC_TYPE = {
   FIXED: 'FIXED',
   DYNAMIC: 'DYNAMIC'
 }
-const LEADING_BUFFER = 2
+const LEADING_BUFFER = 0
 
 export default class Virtual {
   constructor (param, callUpdate) {


### PR DESCRIPTION
**What kind of this PR?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Build-related changes
- [ ] Other, please describe:

**Other information:**
当数量超过 keeps 的时候，当新增节点的同时，在对底部往上移动会导致 range 计算错误
