### PR TITLE
[examples] Add workaround for chromium trapping wheel bug

### DIFF
--- a/example/src/views/chat-room/Main.vue
+++ b/example/src/views/chat-room/Main.vue
@@ -189,6 +189,7 @@ export default {
   border: 2px solid;
   border-bottom: none;
   overflow-y: auto;
+  overscroll-behavior: contain;
   border-color: dimgray;
   display: flex;
   flex-direction: column-reverse;

--- a/example/src/views/dynamic-size/Main.vue
+++ b/example/src/views/dynamic-size/Main.vue
@@ -80,6 +80,7 @@ export default {
   border: 2px solid;
   border-radius: 3px;
   overflow-y: auto;
+  overscroll-behavior: contain;
   border-color: dimgray;
 
   .list-item-dynamic {

--- a/example/src/views/fixed-size/Main.vue
+++ b/example/src/views/fixed-size/Main.vue
@@ -74,6 +74,7 @@ export default {
   border: 2px solid;
   border-radius: 3px;
   overflow-y: auto;
+  overscroll-behavior: contain;
   border-color: dimgray;
 
   .list-item-fixed {

--- a/example/src/views/horizontal/Main.vue
+++ b/example/src/views/horizontal/Main.vue
@@ -75,6 +75,7 @@ export default {
   border: 2px solid;
   border-radius: 3px;
   overflow-x: auto;
+  overscroll-behavior: contain;
   border-color: dimgray;
   display: flex; // when using scrollToBottom()
 

--- a/example/src/views/infinite-loading/Main.vue
+++ b/example/src/views/infinite-loading/Main.vue
@@ -110,6 +110,7 @@ export default {
   border: 2px solid;
   border-radius: 3px;
   overflow-y: auto;
+  overscroll-behavior: contain;
   border-color: dimgray;
   position: relative;
 

--- a/example/src/views/keep-state/Main.vue
+++ b/example/src/views/keep-state/Main.vue
@@ -100,6 +100,7 @@ export default {
   border: 2px solid;
   border-radius: 3px;
   overflow-y: auto;
+  overscroll-behavior: contain;
   border-color: dimgray;
 
   .list-item-keep {

--- a/example/src/views/page-mode/Main.vue
+++ b/example/src/views/page-mode/Main.vue
@@ -74,6 +74,7 @@ export default {
   border: 2px solid;
   border-radius: 3px;
   overflow-y: auto;
+  overscroll-behavior: contain;
   border-color: dimgray;
 
   .list-item-page {


### PR DESCRIPTION
About the bug: [the article](https://www.bennadel.com/blog/3544-trapping-the-wheel-event-may-prevent-chrome-browser-bug-in-which-the-scroll-wheel-stops-working-in-overflow-container.htm) (it has solution with preventing `wheel` behavior)

How to reproduce in any of your demos:

1. Open any example with chrome
2. Start scrolling with wheel in the opposite direction (up if on the top) without moving your cursor
3. Then start scrolling in correct direction

And it won't scroll. This is more important for infinite scroll (or when user expects infinite scrolling). This CSS rule should fix this behavior.

There should be always `overscroll-behavior: contain` on any scrollable list. It more feels like it should be set at lib level.
Should I also add to the example in README?