### PR TITLE
Fix infinite scrollToBottom method

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -848,7 +848,7 @@
           // so we need retry in next event loop until it really at bottom
 
           setTimeout(function () {
-            if (_this.getOffset() + _this.getClientSize() < _this.getScrollSize()) {
+            if (_this.getOffset() + _this.getClientSize() + 1 < _this.getScrollSize()) {
               _this.scrollToBottom();
             }
           }, 3);

--- a/docs/index.js
+++ b/docs/index.js
@@ -790,7 +790,7 @@
           // so we need retry in next event loop until it really at bottom
 
           setTimeout(function () {
-            if (_this.getOffset() + _this.getClientSize() < _this.getScrollSize()) {
+            if (_this.getOffset() + _this.getClientSize() + 1 < _this.getScrollSize()) {
               _this.scrollToBottom();
             }
           }, 3);

--- a/src/index.js
+++ b/src/index.js
@@ -180,7 +180,7 @@ const VirtualList = Vue.component('virtual-list', {
         // maybe list doesn't render and calculate to last range
         // so we need retry in next event loop until it really at bottom
         setTimeout(() => {
-          if (this.getOffset() + this.getClientSize() < this.getScrollSize()) {
+          if (this.getOffset() + this.getClientSize() + 1 < this.getScrollSize()) {
             this.scrollToBottom()
           }
         }, 3)


### PR DESCRIPTION
**What kind of this PR?** (check at least one)

- [x] Bugfix

**Other information:**

In certain condition, the method `scrollToBottom` stuck in infinite loop due to this recursive statement.
```javascript
setTimeout(() => {
  if (this.getOffset() + this.getClientSize() < this.getScrollSize()) {
    this.scrollToBottom()   
  }
}, 3)
```

The condition for checking whether scroll is at bottom or not equals to below.
```javascript
scroller.scrollTop + scroller.clientHeight < scroller.scrollHeight
```

It works usually, but in case that clientHeight is non-integer value, there can be a problem.
Since user agents round those values(in my case, Chrome), sum of scrollTop and clientHeight can be 1px smaller than scrollHeight, though scroll is at bottom.


For example, this was my case.
```
real clientHeight: 533.41
real scrollHeight: 1511.58

rounded clientHeight: 533
rounded scrollHeight: 1512
scrollTop(double, not rounded): 978

scrollTop + clientHeight = 1511 // smaller than scrollHeight though scroll is at bottom
```

I'm not sure how scrollTop value is calculated internally, but tiny change can fix the problem. (https://stackoverflow.com/a/32283147)
