### PR TITLE
fix: totop event was only triggered for once

### DIFF
--- a/src/virtual.js
+++ b/src/virtual.js
@@ -138,7 +138,7 @@ export default class Virtual {
 
   // calculating range on scroll
   handleScroll (offset) {
-    this.direction = offset < this.offset ? DIRECTION_TYPE.FRONT : DIRECTION_TYPE.BEHIND
+    this.direction = offset < this.offset || offset == 0 ? DIRECTION_TYPE.FRONT : DIRECTION_TYPE.BEHIND
     this.offset = offset
 
     if (!this.param) {


### PR DESCRIPTION
**What kind of this PR?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Build-related changes
- [ ] Other, please describe:

**Other information:**
Move the scrollbar to the top and keep the mouse pressed long.
After triggering the first totop event, add some data forward.
The first totop event end,the second to top event will no longer be triggered. 
Since after the first trigger, the this.offset becomes 0, and at the second trigger the handleScroll incoming offset is 0.
For now comparing the two leads to this.direction = BEHIND, which estimates a wrong direction, causing the second totop to be no longer triggered.