### PR TITLE
Fix remove useless "lastCalcIndex" judgment

### DIFF
--- a/src/virtual.js
+++ b/src/virtual.js
@@ -27,7 +27,6 @@ export default class Virtual {
     this.sizes = new Map()
     this.firstRangeTotalSize = 0
     this.firstRangeAverageSize = 0
-    this.lastCalcIndex = 0
     this.fixedSizeValue = 0
     this.calcType = CALC_TYPE.INIT
 
@@ -226,10 +225,6 @@ export default class Virtual {
       offset = offset + (typeof indexSize === 'number' ? indexSize : this.getEstimateSize())
     }
 
-    // remember last calculate index
-    this.lastCalcIndex = Math.max(this.lastCalcIndex, givenIndex - 1)
-    this.lastCalcIndex = Math.min(this.lastCalcIndex, this.getLastIndex())
-
     return offset
   }
 
@@ -297,13 +292,7 @@ export default class Virtual {
       return (lastIndex - end) * this.fixedSizeValue
     }
 
-    // if it's all calculated, return the exactly offset
-    if (this.lastCalcIndex === lastIndex) {
-      return this.getIndexOffset(lastIndex) - this.getIndexOffset(end)
-    } else {
-      // if not, use a estimated value
-      return (lastIndex - end) * this.getEstimateSize()
-    }
+    return (lastIndex - end) * this.getEstimateSize()
   }
 
   // get the item estimate size


### PR DESCRIPTION
**What kind of this PR?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Build-related changes
- [ ] Other, please describe:

**Other information:**
1.Since the scroll range of the container = [0 ~ scrollHeight-clientHeight],
  so lastCalcIndex is never equal to lastIndex.
2.When not scrolling to the bottom, paddingTop affects the position of the real element in the viewport, but paddingBottom 
  does not
3.When scrolling to the bottom, paddingBottom = (last - end) * this.getEstimateSize(),
  since last - end = 0, so it is the right result



